### PR TITLE
Update README.md - syntax error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Example usage:
 
 ```
 <MobiledocEditor
-  :placeholder="Start Writing..."
+  placeholder="Start Writing..."
   @postWasUpdated="savePost">
 </MobiledocEditor>
 ```


### PR DESCRIPTION
In the example, `:placeholder="Start Writing..."` is invalid, you can either remove the binding `:` or make the value a string or variable - for example, this would also work. `:placeholder="'Start Writing...'"`

I thought it was easiest to just remove the v-bind. 